### PR TITLE
Update User id type

### DIFF
--- a/src/arena_service.ts
+++ b/src/arena_service.ts
@@ -142,7 +142,7 @@ export interface ArenaApi {
 
   channels(options?: PaginationAttributes): Promise<GetChannelsApiResponse>;
 
-  user(id: string): ArenaUserApi;
+  user(id: number): ArenaUserApi;
 
   group(slug: string): ArenaGroupApi;
 
@@ -185,7 +185,7 @@ export class ArenaClient implements ArenaApi {
     return this.getJsonWithPaginationQuery('channels', options);
   }
 
-  user(id: string): ArenaUserApi {
+  user(id: number): ArenaUserApi {
     return {
       get: (): Promise<GetUserApiResponse> => this.getJson(`users/${id}`),
       channels: (options?: PaginationAttributes) =>

--- a/tests/arena_service.test.ts
+++ b/tests/arena_service.test.ts
@@ -71,12 +71,12 @@ describe('ArenaClient', () => {
           date: fakeDate,
         });
         await expect(
-          client.user('fake-user-id').channels()
+          client.user(123456).channels()
         ).resolves.toMatchObject(fakeResponseBody);
         expect(fetch).toBeCalledTimes(1);
         expect(fetch).toBeCalledWith(
           expect.stringMatching(
-            'https://api.are.na/v2/users/fake-user-id/channels?'
+            'https://api.are.na/v2/users/123456/channels?'
           ),
           {
             headers: {


### PR DESCRIPTION
This changes `ArenaUserAPI`'s `id` property to be `number` instead of `string`, in order to match the API and the `ArenaUser` type. 

(Wasn't sure if I should run the docs build script for a PR. Can do so if needed!) 