### PR TITLE
Use environment-agnostic default `fetch`

### DIFF
--- a/src/arena_service.ts
+++ b/src/arena_service.ts
@@ -173,7 +173,7 @@ export class ArenaClient implements ArenaApi {
       'Content-Type': 'application/json',
       Authorization: config?.token ? `Bearer ${config.token}` : '',
     };
-    this.fetch = config?.fetch || (window?.fetch.bind(window) as any as Fetch);
+    this.fetch = config?.fetch ||  fetch;
     this.date = config?.date || Date;
   }
 


### PR DESCRIPTION
Modern versions of `Node.js` have support for a similar `fetch` api to the browser's, but `window` is obviously not available in a server context. The Node function supports the same `Fetch` type declared in the server This allows us to avoid having to provide a default fetch function in server environments.