### PR TITLE
Allow ArenaApi.user to accept either a slug (string) or id (number)

### DIFF
--- a/src/arena_service.ts
+++ b/src/arena_service.ts
@@ -145,7 +145,7 @@ export interface ArenaApi {
 
   channels(options?: PaginationAttributes): Promise<GetChannelsApiResponse>;
 
-  user(id: number): ArenaUserApi;
+  user(id: number | string): ArenaUserApi;
 
   group(slug: string): ArenaGroupApi;
 
@@ -188,7 +188,7 @@ export class ArenaClient implements ArenaApi {
     return this.getJsonWithPaginationQuery('channels', options);
   }
 
-  user(id: number): ArenaUserApi {
+  user(id: number | string): ArenaUserApi {
     return {
       get: (): Promise<GetUserApiResponse> => this.getJson(`users/${id}`),
       channels: (options?: PaginationAttributes) =>


### PR DESCRIPTION
I've determined this to be supported by the are.na API - so much nicer to pass the slug (i.e. `jake-isnt`) than the id (12312 or something)!