### PR TITLE
Provide 'repository' link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "A typescript API client for Are.na",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "repository": { 
+    "type": "git", 
+    "url": "https://github.com/e-e-e/arena-ts.git" 
+  }, 
   "scripts": {
     "build": "tsc -b tsconfig.build.json",
     "dev": "tsc -b tsconfig.build.json -w",


### PR DESCRIPTION
This allows the NPM page to directly link to this repository, making the source easier to find