### PR TITLE
Remove ArenaBaseBlock from ArenaBlock enum

### DIFF
--- a/src/arena_api_types.ts
+++ b/src/arena_api_types.ts
@@ -218,7 +218,6 @@ export type ArenaAttachmentBlock = ArenaBaseBlock & {
 };
 
 export type ArenaBlock =
-  | ArenaBaseBlock
   | ArenaImageBlock
   | ArenaTextBlock
   | ArenaLinkBlock


### PR DESCRIPTION
This allows us to differentiate between blocks with the class property alone. Without it, strict typescript does not know how to differentiate.